### PR TITLE
Update `WorkGiver_HaulRottable.cs`

### DIFF
--- a/Source/RefactoredWorkPriorities/WorkGiver_HaulRottable.cs
+++ b/Source/RefactoredWorkPriorities/WorkGiver_HaulRottable.cs
@@ -16,7 +16,7 @@ public class WorkGiver_HaulRottable : WorkGiver_HaulGeneral
 
     public override IEnumerable<Thing> PotentialWorkThingsGlobal(Pawn pawn)
     {
-        return from t in pawn.Map.listerHaulables.ThingsPotentiallyNeedingHauling()
+        return from t in pawn.Map.listerHaulables.ThingsPotentiallyNeedingHauling().ToArray()
             where t.def.comps.Exists(tc => tc.compClass == typeof(CompRottable))
             select t;
     }


### PR DESCRIPTION
The same issue exists here too. NOTE: I do not understand why the other function checks the same members for `null` but not this. I left this code as is, it's up to you to decide if you wish to do something about that. I'd suggest to verify if they could plausibly be `null` and remove the checks.